### PR TITLE
:bug: fix regex error for python 3.10

### DIFF
--- a/generate.js
+++ b/generate.js
@@ -65,16 +65,16 @@ function getPythonLibraryIndexes (pythoneVersionDir, indexes) {
       indexes.push({ t, p: 'library/' + f, d })
       isUse = true
     }
-    const dlMatchs = htmlContent.match(/<dl class="[^"]*(?:class|function|method|data|attribute)">\s*?<dt id="[^"\n]+?">[\s\S]+?<dd><p>[\s\S]+?<\/p>/g)
+    const dlMatchs = htmlContent.match(/<dl class="[^"]*(?:class|function|method|data|attribute)">\s*?<dt(?: class="[^"]*")? id="[^"\n]+?">[\s\S]+?<dd><p>[\s\S]+?<\/p>/g)
     if (dlMatchs) {
       dlMatchs.forEach(dl => {
-        const maches = dl.match(/<dl class="[^"]*(?:class|function|method|data|attribute)">\s*?<dt id="([^"\n]+?)">([\s\S]+?)<dd><p>([\s\S]+?)<\/p>/)
-        const id = maches[1].trim()
-        const checkNextContent = maches[2]
-        const d = removeHtmlTag(maches[3]).replace(/\s+/g, ' ').trim()
-        if (checkNextContent.includes('<dt id="')) {
-          checkNextContent.match(/<dt id="[^"\n]+?">/g).forEach(nx => {
-            const nid = nx.match(/<dt id="([^"\n]+?)">/)[1]
+        const matches = dl.match(/<dl class="[^"]*(?:class|function|method|data|attribute)">\s*?<dt(?: class="[^"]*")? id="([^"\n]+?)">([\s\S]+?)<dd><p>([\s\S]+?)<\/p>/)
+        const id = matches[1].trim()
+        const checkNextContent = matches[2]
+        const d = removeHtmlTag(matches[3]).replace(/\s+/g, ' ').trim()
+        if (checkNextContent.includes('<dt')) {
+          checkNextContent.match(/<dt(?: class="[^"]*")? id="[^"\n]+?">/g).forEach(nx => {
+            const nid = nx.match(/<dt(?: class="[^"]*")? id="([^"\n]+?)">/)[1]
             indexes.push({ t: nid, p: 'library/' + f + '#' + nid, d })
           })
         }
@@ -83,10 +83,10 @@ function getPythonLibraryIndexes (pythoneVersionDir, indexes) {
       isUse = true
     }
     // 存在可能重复的ID  python文档的方式是用 target 处理
-    const targetMatchs = htmlContent.match(/<span class="target" id="[^"\n]+?"><\/span>\s*?<dl class="(?:class|function|method|data|attribute)">\s*?<dt>[\s\S]+?<dd><p>[\s\S]+?<\/p>/g)
+    const targetMatchs = htmlContent.match(/<span class="target" id="[^"\n]+?"><\/span>\s*?<dl class="[^"]*(?:class|function|method|data|attribute)">\s*?<dt>[\s\S]+?<dd><p>[\s\S]+?<\/p>/g)
     if (targetMatchs) {
       targetMatchs.forEach(tt => {
-        const maches = tt.match(/<span class="target" id="([^"\n]+?)"><\/span>\s*?<dl class="(?:class|function|method|data|attribute)">\s*?<dt>[\s\S]+?<dd><p>([\s\S]+?)<\/p>/)
+        const maches = tt.match(/<span class="target" id="([^"\n]+?)"><\/span>\s*?<dl class="[^"]*(?:class|function|method|data|attribute)">\s*?<dt>[\s\S]+?<dd><p>([\s\S]+?)<\/p>/)
         let id = maches[1].trim()
         let kid = id
         if (id.includes('-')) {

--- a/generate.js
+++ b/generate.js
@@ -59,16 +59,16 @@ function getPythonLibraryIndexes (pythoneVersionDir, indexes) {
     if (!f.endsWith('.html')) return
     let isUse = false
     const htmlContent = fs.readFileSync(path.join(libraryDir, f), { encoding: 'utf-8' })
-    if (/<h1>(?:\d{1,2}\.\d{1,2}\. )?<a[^>\n]+?><code[^>\n]+?><span class="pre">(.+?)<\/span><\/code><\/a>\s*?(?:---|—)(.+?)<a class="headerlink".+?<\/h1>/.test(htmlContent)) {
+    if (/<h1>(?:\d{1,2}\.\d{1,2}\. )?(?:<a[^>\n]+?>)?(?:<code[^>\n]+?><span class="pre">)?([^<]+)(?:<\/span><\/code>)?(?:<\/a>)?\s*?(?:(?:---|—)(.+?))?<a class="headerlink".+?<\/h1>/.test(htmlContent)) {
       const t = removeHtmlTag(RegExp.$1.trim())
       const d = removeHtmlTag(RegExp.$2.trim())
       indexes.push({ t, p: 'library/' + f, d })
       isUse = true
     }
-    const dlMatchs = htmlContent.match(/<dl class="(?:class|function|method|data|attribute)">\s*?<dt id="[^"\n]+?">[\s\S]+?<dd><p>[\s\S]+?<\/p>/g)
+    const dlMatchs = htmlContent.match(/<dl class="[^"]*(?:class|function|method|data|attribute)">\s*?<dt id="[^"\n]+?">[\s\S]+?<dd><p>[\s\S]+?<\/p>/g)
     if (dlMatchs) {
       dlMatchs.forEach(dl => {
-        const maches = dl.match(/<dl class="(?:class|function|method|data|attribute)">\s*?<dt id="([^"\n]+?)">([\s\S]+?)<dd><p>([\s\S]+?)<\/p>/)
+        const maches = dl.match(/<dl class="[^"]*(?:class|function|method|data|attribute)">\s*?<dt id="([^"\n]+?)">([\s\S]+?)<dd><p>([\s\S]+?)<\/p>/)
         const id = maches[1].trim()
         const checkNextContent = maches[2]
         const d = removeHtmlTag(maches[3]).replace(/\s+/g, ' ').trim()

--- a/generate.js
+++ b/generate.js
@@ -28,7 +28,7 @@ function writeHtmlFile (filePath, htmlContent, pythonVersion) {
 
 // 语言参考索引
 function getPythonReferenceIndexes (pythoneVersionDir, indexes) {
-  const pythonVersion = pythoneVersionDir.match(/python-(\d\.\d)/)[1]
+  const pythonVersion = pythoneVersionDir.match(/python-(\d\.\d+)/)[1]
   const pubPath = path.join(__dirname, 'public', 'python-' + pythonVersion)
   const indexHtmlContent = fs.readFileSync(path.join(__dirname, pythoneVersionDir, 'reference', 'index.html'), { encoding: 'utf-8' })
   const matchs = indexHtmlContent.match(/<li class="toctree-l\d">\s*<a class="reference internal" href="[^"\n]+?">[\s\S]+?<\/a>/g)
@@ -51,7 +51,7 @@ function getPythonReferenceIndexes (pythoneVersionDir, indexes) {
 
 // Python 标准库索引
 function getPythonLibraryIndexes (pythoneVersionDir, indexes) {
-  const pythonVersion = pythoneVersionDir.match(/python-(\d\.\d)/)[1]
+  const pythonVersion = pythoneVersionDir.match(/python-(\d\.\d+)/)[1]
   const pubPath = path.join(__dirname, 'public', 'python-' + pythonVersion)
   const libraryDir = path.join(__dirname, pythoneVersionDir, 'library')
   const files = fs.readdirSync(libraryDir)
@@ -110,7 +110,7 @@ function main () {
   var args = process.argv.slice(2)
   const indexes = []
   const pythoneVersionDir = args[0]
-  if (!/python-(\d\.\d)/.test(pythoneVersionDir)) throw new Error('文件夹错误')
+  if (!/python-(\d\.\d+)/.test(pythoneVersionDir)) throw new Error('文件夹错误')
   const pythonVersion = RegExp.$1
   if (!fs.existsSync(path.join(__dirname, pythoneVersionDir))) throw new Error(pythoneVersionDir + '文件夹不存在')
   const pubPath = path.join(__dirname, 'public', 'python-' + pythonVersion)

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "1.0.0",
   "description": "Python 文档",
   "scripts": {
+    "3.11": "node generate.js python-3.11.1-docs-html",
     "3.10": "node generate.js python-3.10.0-docs-html",
     "3.9": "node generate.js python-3.9.8-docs-html",
     "3.8": "node generate.js python-3.8.0-docs-html",

--- a/package.json
+++ b/package.json
@@ -3,6 +3,8 @@
   "version": "1.0.0",
   "description": "Python 文档",
   "scripts": {
+    "3.10": "node generate.js python-3.10.0-docs-html",
+    "3.9": "node generate.js python-3.9.8-docs-html",
     "3.8": "node generate.js python-3.8.0-docs-html",
     "3.7": "node generate.js python-3.7.5-docs-html",
     "3.6": "node generate.js python-3.6.9-docs-html",


### PR DESCRIPTION
Python 3.10 已经发布，但是构建过程中的正则表达式 `python-(\d\.\d)` 并不能正确识别python的版本号，以及html的一些class变动导致索引regex识别失败